### PR TITLE
Added RSS feed for door.link.

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -184,7 +184,20 @@ export default function Header({ darkTheme, dark, selectedTrack }) {
           >
             Subscribe
           </Typography>
-          {/* 
+          <Link
+            href="/rss.xml"
+            rel="noopener"
+            target="_blank"
+          >
+            <Typography
+              variant="body2"
+              style={{ marginRight: "10px" }}
+              color="primary"
+            >
+              RSS
+            </Typography>
+          </Link>
+          {/*
           <Link
             href="https://www.patreon.com/doordotlink"
             rel="noopener"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,9 +1066,9 @@
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001159",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz",
-      "integrity": "sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA=="
+      "version": "1.0.30001237",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001237.tgz",
+      "integrity": "sha512-pDHgRndit6p1NR2GhzMbQ6CkRrp4VKuSsqbcLeOQppYPKOYkKT/6ZvZDvKJUqcmtyWIAHuZq3SVS2vc1egCZzw=="
     },
     "chalk": {
       "version": "2.4.2",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -45,6 +45,11 @@ export default class MyDocument extends Document {
             property="og:image:alt"
             content="this is the logo of door.link, used as an open graph"
           />
+          <link
+            rel="alternate" type="application/rss+xml"
+            title="Subscribe to the RSS feed."
+            href="https://door.link/rss.xml"
+          />
 
           {/* <meta name="theme-color" content={theme.palette.primary.main} /> */}
         </Head>

--- a/pages/api/playlist.js
+++ b/pages/api/playlist.js
@@ -1,0 +1,16 @@
+export const getPlaylist = async () => {
+  const { API_URL } = process.env;
+  const playlist = await fetch(`${API_URL}/playlists?_sort=created_at:desc`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+  const data = await playlist.json();
+  return data;
+};
+
+const Playlist = async (req, res) =>
+  res.status(200).json(await getPlaylist());
+
+export default Playlist;

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,6 +10,9 @@ import Playlist from "../components/playlist";
 import Player from "../components/player";
 import Header from "../components/header";
 
+//Playlist object
+import { getPlaylist } from "./api/playlist";
+
 const useStyles = makeStyles((theme) => ({
   container: {
     height: "100%",
@@ -83,15 +86,7 @@ export default function Home({ playlists, darkTheme, dark }) {
 }
 
 export async function getStaticProps() {
-  const { API_URL } = process.env;
-  const res = await fetch(`${API_URL}/playlists?_sort=created_at:desc`, {
-    method: "GET",
-    headers: {
-      "Content-Type": "application/json",
-    },
-  });
-  const data = await res.json();
-  console.log("res", res);
+  const data = await getPlaylist();
   return {
     props: {
       playlists: data,

--- a/pages/rss.xml.js
+++ b/pages/rss.xml.js
@@ -1,0 +1,90 @@
+import { Component } from "react";
+
+import { getPlaylist } from "./api/playlist";
+
+if (!String.prototype.encodeXML) {
+  String.prototype.encodeXML = function () {
+    return this
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&apos;');
+  };
+}
+
+const TagWriter = writer => ({
+  write: (tag, attrs, content, indent=0, isVoid=false) => {
+    const tab = '  '.repeat(indent);
+    writer.write(`${tab}<${tag}`);
+    if (Object.entries(attrs).length > 0)
+      writer.write(' ' +
+        Object.keys(attrs)
+          .map(key => `${key}="${attrs[key]}"`)
+          .join(' '));
+    if (isVoid)
+      writer.write(` />\n`);
+    else
+      writer.write(`>${content.encodeXML()}</${tag}>\n`);
+  },
+  open: (tag, attrs={}, indent=0) => {
+    const tab = '  '.repeat(indent);
+    writer.write(`${tab}<${tag}`);
+    if (Object.entries(attrs).length > 0)
+      writer.write(' ' +
+        Object.keys(attrs)
+          .map(key => `${key}="${attrs[key]}"`)
+          .join(' '));
+    writer.write('>\n');
+  },
+  close: (tag, indent=0) => {
+    const tab = '  '.repeat(indent);
+    writer.write(`${tab}</${tag}>\n`);
+  }
+});
+
+export default class RSS extends Component {
+  static async getInitialProps({ res }) {
+    const tag = TagWriter(res);
+
+    res.setHeader('Content-Type', 'text/xml');
+    res.write(`<?xml version="1.0" encoding="UTF-8"?>\n`);
+    tag.open('rss', {
+      version: "2.0",
+      "xmlns:atom": "http://www.w3.org/2005/Atom"
+    });
+
+    // Channel information.
+    tag.open('channel');
+    tag.write('title', {}, "[ door ]", 1);
+    tag.write('description', {}, 'A curated selection of music for listening'
+      + ' and dancing in small, safe spaces.', 1);
+    tag.write('language', {}, "en-us", 1);
+    tag.write('link', {}, "https://door.link/rss.xml", 1);
+    tag.write('atom:link', {
+      href: "https://door.link/rss.xml",
+      rel: "self",
+      type: "application/rss+xml"
+    }, null, 1, true);
+    // Generate entries.
+    const entries = await getPlaylist();
+    for (const entry of entries) {
+      const { audio } = entry;
+      tag.open('item', {}, 1);
+      tag.write('title', {}, entry.Title, 2);
+      tag.write('guid', {}, audio.hash, 2);
+      tag.write('link', {}, "https://door.link/", 2);
+      tag.write('enclosure', {
+        url: audio.url, type: audio.mime,
+        length: Math.trunc(audio.size * 1000)
+      }, null, 2, true);
+      tag.write('description', {}, entry.Description.trim(), 2);
+      tag.write('pubDate', {}, entry.published_at, 2);
+      tag.close('item', 1);
+    }
+    // Close remaining tags.
+    tag.close('channel');
+    tag.close('rss');
+    res.end();
+  }
+}


### PR DESCRIPTION
I personally find it most convenient to keep up-to-date with online events and affairs through an RSS or Atom feed.  Would be really great if door.link had a feed, so I can keep up with uploads.

I implemented a quick `/rss.xml` page, which generates the feed from the JSON file served by your API, and added a link to it in the header.