### PR TITLE
Feature to restore last playing session

### DIFF
--- a/components/player.js
+++ b/components/player.js
@@ -9,7 +9,7 @@ import Plyr from "plyr-react";
 import "plyr-react/dist/plyr.css";
 
 export default function Player() {
-  const { selectedTrack, setSelectedTrack } = useContext(TrackContext);
+  const { selectedTrack, setSelectedTrack, player } = useContext(TrackContext);
   const { theme } = useTheme();
   const audioSrc = {
     type: "audio",
@@ -43,6 +43,7 @@ export default function Player() {
       <Plyr
         source={audioSrc}
         autoPlay
+        ref={player}
         style={
           theme === "dark"
             ? {

--- a/context/trackContext.js
+++ b/context/trackContext.js
@@ -1,12 +1,38 @@
-import { createContext, useState } from "react";
+import { createContext, useState, useRef, useEffect } from "react";
+import { throttle } from '../utils/throttle'
 
 export const TrackContext = createContext();
 
 export function TrackProvider({ children }) {
   const [selectedTrack, setSelectedTrack] = useState(null);
+  const player = useRef();
+
+  useEffect(() => {
+    const saveCurrentTrack = throttle(({ detail }) => {
+      if(detail.plyr.playing) {
+        const payload = {
+          id: selectedTrack.id,
+          currentTime: detail.plyr.currentTime
+        }
+        localStorage.setItem('lastPlayedTrackInfo', JSON.stringify(payload))
+      }
+    }, 1000)
+
+    if (selectedTrack && player && player.current) {
+      const { plyr } = player.current
+      plyr.on('timeupdate', saveCurrentTrack)
+    }
+    return () => {
+      if (player && player.current) {
+        const { plyr  } = player.current
+        plyr.off('timeupdate')
+        localStorage.setItem('lastPlayedTrackInfo', '')
+      }
+    }
+  }, [selectedTrack, player, player.current])
 
   return (
-    <TrackContext.Provider value={{ selectedTrack, setSelectedTrack }}>
+    <TrackContext.Provider value={{ selectedTrack, setSelectedTrack, player }}>
       {children}
     </TrackContext.Provider>
   );

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import { useContext } from "react";
+import { useContext, useEffect } from "react";
 import { TrackContext } from "../context/trackContext";
 
 //Components
@@ -10,7 +10,7 @@ import Player from "../components/player";
 import { getPlaylist } from "./api/playlist";
 
 export default function Home({ playlists }) {
-  const { selectedTrack } = useContext(TrackContext);
+  const { selectedTrack, setSelectedTrack } = useContext(TrackContext);
 
   const tracks = playlists.map((track) => {
     return {
@@ -23,6 +23,19 @@ export default function Home({ playlists }) {
       image: track.artwork.url,
     };
   });
+
+  useEffect(() => {
+    const lastPlayedTrackInfo = localStorage.getItem('lastPlayedTrackInfo')
+
+    if (lastPlayedTrackInfo) {
+      const { currentTime, id } = JSON.parse(lastPlayedTrackInfo)
+      const targetTrack = tracks.find((track) => track.id === id)
+      setSelectedTrack({
+        ...targetTrack,
+        url: `${targetTrack.url}#t=${Math.round(currentTime)}`
+      })
+    }
+  }, [])
 
   return (
     <div className="max-w-7xl mx-auto bg-white dark:bg-[#121212] pb-10">

--- a/utils/throttle.js
+++ b/utils/throttle.js
@@ -1,0 +1,10 @@
+export const throttle = (callback, delay = 100) => {
+    let throttle = false;
+    return function (...args) {
+        if (throttle) { return; } 
+        throttle = setTimeout(function () {
+            callback.apply(this, args);
+            throttle = false;
+        }, delay);
+    };
+};


### PR DESCRIPTION
###### _Apologies for the unsolicited PR_

### Description

Adds a new functionality to the site where the last played track resumes at the time it was played.

- Uses localstorage to store the `currentTime` and `id` of a track if there's one playing.
- Restores last session upon visiting the index page. (Mixtape routes are not included)

### Caveat

It seems that plyr-react's `listeners`does not actually work with this setup so I had to attach listeners manually.

---

Happy to explore further or make adjustment. ✌️